### PR TITLE
removed toString() to prevent throwing NPEs

### DIFF
--- a/heat-core-utils/src/main/java/com/hotels/heat/core/listeners/CustomTestNgListener.java
+++ b/heat-core-utils/src/main/java/com/hotels/heat/core/listeners/CustomTestNgListener.java
@@ -137,12 +137,12 @@ public class CustomTestNgListener extends TestListenerAdapter {
         }
         if (numTestSkipped > 0 && numTestSuccess == 0 && numTestFailed == 0) {
             // test suite totally skipped
-            logger.trace("*************[{}][Suite description: {}] SKIPPED Test Suite", testName, testContext.getAttribute(TestBaseRunner.SUITE_DESCRIPTION_CTX_ATTR).toString());
+            logger.trace("*************[{}][Suite description: {}] SKIPPED Test Suite", testName, testContext.getAttribute(TestBaseRunner.SUITE_DESCRIPTION_CTX_ATTR));
             logger.info("*************[{}][{}] END Test Suite: Success: {} / Failed: {} / Skipped: {}",
-                testName, testContext.getAttribute(TestBaseRunner.SUITE_DESCRIPTION_CTX_ATTR).toString(), numTestSuccess, numTestFailed, numTestSkipped);
+                testName, testContext.getAttribute(TestBaseRunner.SUITE_DESCRIPTION_CTX_ATTR), numTestSuccess, numTestFailed, numTestSkipped);
         } else {
             logger.debug("*************[{}][{}] END Test Suite: Success: {} / Failed: {} / Skipped: {}",
-                testName, testContext.getAttribute(TestBaseRunner.SUITE_DESCRIPTION_CTX_ATTR).toString(), numTestSuccess, numTestFailed, numTestSkipped);
+                testName, testContext.getAttribute(TestBaseRunner.SUITE_DESCRIPTION_CTX_ATTR), numTestSuccess, numTestFailed, numTestSkipped);
         }
 
         if (numTestFailed > 0) {


### PR DESCRIPTION
do not use `toString()` in log parameters to prevent `NullPointerException`s when value is `null`. 
Partly mitigates https://github.com/HotelsDotCom/heat/issues/10, removing these lines: 
``com.hotels.heat.core.listeners.CustomTestNgListener.onFinish(CustomTestNgListener.java:140)``